### PR TITLE
Bump goofys version, removed default ENDPOINT and added UID/GID (#6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,20 @@ MAINTAINER Cloud Posse, LLC
 
 RUN apk update && apk add gcc ca-certificates openssl musl-dev git fuse syslog-ng coreutils curl
 
-ENV GOOFYS_VERSION 0.19.0
+ENV GOOFYS_VERSION 0.23.1
 RUN curl --fail -sSL -o /usr/local/bin/goofys https://github.com/kahing/goofys/releases/download/v${GOOFYS_VERSION}/goofys \
     && chmod +x /usr/local/bin/goofys
 
+ARG ENDPOINT
 ENV MOUNT_DIR /mnt/s3
 ENV REGION us-east-1
-ENV ENDPOINT https://s3.amazonaws.com
 ENV BUCKET teleport-bucket
 ENV STAT_CACHE_TTL 1m0s
 ENV TYPE_CACHE_TTL 1m0s
 ENV DIR_MODE 0700
 ENV FILE_MODE 0600
+ENV UID 0
+ENV GID 0
 
 RUN mkdir /mnt/s3
 

--- a/rootfs/usr/bin/run.sh
+++ b/rootfs/usr/bin/run.sh
@@ -2,4 +2,4 @@
 
 syslog-ng -f /etc/syslog-ng/syslog-ng.conf
 
-goofys -f --endpoint $ENDPOINT --region $REGION --stat-cache-ttl $STAT_CACHE_TTL --type-cache-ttl $TYPE_CACHE_TTL --dir-mode $DIR_MODE --file-mode $FILE_MODE -o nonempty $BUCKET $MOUNT_DIR
+goofys -f ${ENDPOINT:+--endpoint $ENDPOINT} --region $REGION --stat-cache-ttl $STAT_CACHE_TTL --type-cache-ttl $TYPE_CACHE_TTL --dir-mode $DIR_MODE --file-mode $FILE_MODE --uid $UID --gid $GID -o nonempty $BUCKET $MOUNT_DIR


### PR DESCRIPTION
* Bumped kahing/goofys version to avoid "not found" error.  Added optional USER & GROUP options to change the goofys ownership.

* Correctly mapping uid and gid instead of user/group

* Removing default endpoint